### PR TITLE
small-typo fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This Turborepo includes the following packages/apps:
 - `web`: another [Next.js](https://nextjs.org/) app
 - `@repo/ui`: a stub React component library shared by both `web` and `docs` applications
 - `@repo/eslint-config`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
-- `@repo/typescript-config`: `tsconfig.json`s used throughout the monorepo
+- `@repo/typescript-config`: `tsconfig.json` used throughout the monorepo
 
 Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).
 


### PR DESCRIPTION
small typo fixed, removed extra `s`
<br>

![image](https://github.com/akshitagupta15june/PetMe-Prod/assets/91485305/88b47e07-65b1-498f-8a19-7309620ead40)
